### PR TITLE
Auth with only one redis connection

### DIFF
--- a/lib/authentication.js
+++ b/lib/authentication.js
@@ -8,8 +8,9 @@ exports.register = function (server, options, next) {
 
     server.auth.strategy('jwt', 'jwt', true,
     { key: process.env.JWT_SECRET,  validateFunc: validate,
-      verifyOptions: { ignoreExpiration: true }
+      verifyOptions: { ignoreExpiration: true },
     });
+
 
   });
 

--- a/lib/google_oauth_handler.js
+++ b/lib/google_oauth_handler.js
@@ -1,5 +1,4 @@
 var JWT = require('jsonwebtoken'); // session stored as a JWT cookie
-var redisClient = require('redis-connection')();
 
 module.exports = function custom_handler(req, reply, tokens, profile) {
   if(profile) {
@@ -14,11 +13,12 @@ module.exports = function custom_handler(req, reply, tokens, profile) {
     // create a JWT to set as the cookie:
 
     var jwt = JWT.sign(session, process.env.JWT_SECRET);
-    console.log("############JWT", jwt);
     // store the Profile and Oauth tokens in the Redis DB using G+ id as key
     // Detailed Example...? https://github.com/dwyl/hapi-auth-google/issues/2
     profile.tokens = tokens;
     profile.valid = true;
+    //get the current redis connection or create a new one
+    var redisClient = require('redis-connection')();
     redisClient.set(session.id, JSON.stringify(profile), function (err, res) {
       // reply to client with a view
       return reply("Hello " +profile.name.givenName + " You Logged in Using Goolge!")
@@ -31,4 +31,4 @@ module.exports = function custom_handler(req, reply, tokens, profile) {
   }
 }
 
-module.exports.redisClient = redisClient;
+//module.exports.redisClient = redisClient;

--- a/lib/private.js
+++ b/lib/private.js
@@ -6,9 +6,16 @@ exports.register = function (server, option, next) {
       path: '/private',
       config: {
         description: 'return a private page',
-        auth: 'jwt',
+        auth: {
+          mode: 'try',
+          strategy: 'jwt'
+        },
         handler: function (request, reply) {
-          reply('This is a private page');
+          if(!request.auth.isAuthenticated) {
+            return reply.redirect('/');
+          } else {
+            return reply('You are on the private page');
+          }
         }
       }
     }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,22 +1,22 @@
 var Hapi = require('hapi');
 var Home = require('./home.js')
 var HapiAuthGoogle = require('hapi-auth-google');
-var Private = require('./private');
 var Vision = require('vision');
 var Handlebars = require('handlebars');
+var validate = require('./validate');
+var HapiAuthJWT =  require('hapi-auth-jwt2');
+var Private = require('./private.js');
 var Authentication = require('./authentication');
 
 exports.init = function (port, next) {
-
+  // var redisClient = require('redis-connection');
   var server = new Hapi.Server();
   server.connection({port: port});
   var opts = { REDIRECT_URL: '/googleauth',
              scope: 'https://www.googleapis.com/auth/plus.profile.emails.read',
              handler: require('./google_oauth_handler.js') };
 
-  server.register([{register: HapiAuthGoogle, options: opts}, Authentication, Home, Private, Vision], function (err) {
-
-
+  server.register([{register: HapiAuthGoogle, options: opts}, Authentication, Private, Home, Vision], function (err) {
 
     server.views({
       engines: {
@@ -26,8 +26,6 @@ exports.init = function (port, next) {
       path: '.',
       layout: 'default',
       layoutPath: 'layout'
-      // helpersPath: 'helpers',
-      // partialsPath: 'partials'
     });
     server.start(function (err) {
 

--- a/test/private.test.js
+++ b/test/private.test.js
@@ -76,7 +76,6 @@ test("Authentication failed: right JWT token but valid property is false", funct
       server.inject(options, function(response) {
         t.equal(response.statusCode, 302, "Right token but property valid false! Redirection to /");
         server.stop(function(){
-          redisClient.end();
         });
         t.end();
       });
@@ -97,6 +96,9 @@ test("Authentication failed: right token but user doesn't exist in Redis", funct
     server.inject(options, function(response) {
       t.equal(response.statusCode, 302, "Right Token but user doesn't exist in Redis!, Redirection to /");
       server.stop(t.end);
+      //get the current redis connection and close it
+      var redisClient = require('redis-connection')();
+      redisClient.end();
     });
   })
 });

--- a/test/private.test.js
+++ b/test/private.test.js
@@ -4,7 +4,6 @@ var test = require('tape');
 var dir  = __dirname.split('/')[__dirname.split('/').length-1];
 var file = dir + __filename.replace(__dirname, '') + " > ";
 var fs = require('fs');
-var redisClient = require('redis-connection')();
 
 test(file+'Visit /private without a JWT cookie', function(t) {
 
@@ -15,7 +14,7 @@ test(file+'Visit /private without a JWT cookie', function(t) {
 
   Server.init(0, function (err, server) {
     server.inject(options, function(response) {
-      t.equal(response.statusCode, 401, "endpoint /private 401 not Authorized: No cookie sent to the server");
+      t.equal(response.statusCode, 302, "endpoint /private 302 not Authorized: No cookie sent to the server, redirect to /");
       server.stop(t.end);
     });
   })
@@ -32,7 +31,7 @@ test("Attempt to access restricted content with WRONG Token", function(t) {
   // server.inject lets us similate an http request
   Server.init(0, function (err, server) {
     server.inject(options, function(response) {
-      t.equal(response.statusCode, 401, "Try to access the private page with a wrong Token !");
+      t.equal(response.statusCode, 302, "Try to access the private page with a wrong Token!, Redirection to /");
       server.stop(t.end);
     });
   })
@@ -40,7 +39,6 @@ test("Attempt to access restricted content with WRONG Token", function(t) {
 
 test("Authentication ok: right JWT token and valid property to true", function(t) {
 
-  redisClient.set(12, JSON.stringify({ id: 12, "name": "Simon", valid: true}), function (err, res) {
 
     var token =  JWT.sign({ id: 12, "name": "Simon", valid: true}, process.env.JWT_SECRET);
     var options = {
@@ -50,6 +48,8 @@ test("Authentication ok: right JWT token and valid property to true", function(t
     };
     // server.inject lets us similate an http request
     Server.init(0, function (err, server) {
+      var redisClient = require('redis-connection')();
+      redisClient.set(12, JSON.stringify({ id: 12, "name": "Simon", valid: true}), function (err, res) {
       server.inject(options, function(response) {
         t.equal(response.statusCode, 200, "Get the private page: Right JWT token!");
         server.stop(function(){
@@ -62,7 +62,6 @@ test("Authentication ok: right JWT token and valid property to true", function(t
 
 test("Authentication failed: right JWT token but valid property is false", function(t) {
 
-  redisClient.set(123, JSON.stringify({ id: 123, "name": "Charlie", valid: false}), function (err, res) {
 
     var token =  JWT.sign({ id: 123, "name": "Charlie"}, process.env.JWT_SECRET);
     var options = {
@@ -72,8 +71,10 @@ test("Authentication failed: right JWT token but valid property is false", funct
     };
     // server.inject lets us similate an http request
     Server.init(0, function (err, server) {
+      var redisClient = require('redis-connection')();
+      redisClient.set(123, JSON.stringify({ id: 123, "name": "Charlie", valid: false}), function (err, res) {
       server.inject(options, function(response) {
-        t.equal(response.statusCode, 401, "Right token but property valid false !");
+        t.equal(response.statusCode, 302, "Right token but property valid false! Redirection to /");
         server.stop(function(){
           redisClient.end();
         });
@@ -94,7 +95,7 @@ test("Authentication failed: right token but user doesn't exist in Redis", funct
   // server.inject lets us similate an http request
   Server.init(0, function (err, server) {
     server.inject(options, function(response) {
-      t.equal(response.statusCode, 401, "Right Token but user doesn't exist in Redis!");
+      t.equal(response.statusCode, 302, "Right Token but user doesn't exist in Redis!, Redirection to /");
       server.stop(t.end);
     });
   })

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,7 +1,7 @@
 require('env2')('.env');
 var googleAuthHandler = require('../lib/google_oauth_handler');
-var validate = require('../lib/validate.js');
-var redisClient = require('redis-connection')();
+//var validate = require('../lib/validate.js');
+//var redisClient = require('redis-connection')();
 var test = require('tape');
 var Server = require('../lib/server.js');
 var dir  = __dirname.split('/')[__dirname.split('/').length-1];
@@ -80,9 +80,11 @@ test('Mock /googleauth?code=oauth2codehere', function(t) {
       console.log(response.payload);
       console.log(' - - - - - - - - - - - - - - - - - -');
       server.stop(function(){
+        //get the redis connection and close it
+        var redisClient = require('redis-connection')();
         redisClient.end();
-        googleAuthHandler.redisClient.end();
-        validate.redisClient.end();
+        //googleAuthHandler.redisClient.end();
+        //validate.redisClient.end();
         t.end();
       });
     });

--- a/test/server.test.js
+++ b/test/server.test.js
@@ -1,7 +1,5 @@
 require('env2')('.env');
 var googleAuthHandler = require('../lib/google_oauth_handler');
-//var validate = require('../lib/validate.js');
-//var redisClient = require('redis-connection')();
 var test = require('tape');
 var Server = require('../lib/server.js');
 var dir  = __dirname.split('/')[__dirname.split('/').length-1];


### PR DESCRIPTION
By requiring the package redis-connection just before using it, we are sure that we are not creating a new connection in our tests
